### PR TITLE
Added "The Math Behind Artificial Intelligence". A free freeCodeCamp book to the DL Books section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ JAX is a combination of Automatic Differentiation and XLA (Accelerated Linear AL
 
 - [The Deep Learning textbook](https://www.deeplearningbook.org/) by Ian Goodfellow, Yoshua Bengio and Aaron Courville. Includes lectures in `.key` and `.pdf` formats, [videos discussing different chapters](https://www.youtube.com/channel/UCF9O8Vj-FEbRDA5DcDGz-Pg/videos). https://www.deeplearningbook.org/
 
+- [The Math Behind Artificial Intelligence: A Guide to AI Foundations [Full Book]](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book/) - Free book teaching the math behind AI with plain English explanations and Python code examples
+
 - [Fundamentals-of-Deep-Learning-Book](https://github.com/darksigma/Fundamentals-of-Deep-Learning-Book) - Python code companion to the O'Reilly "[Fundamentals of Deep Learning](http://shop.oreilly.com/product/0636920039709.do)" book
 
 - [Dive into Deep Learning](https://d2l.ai/) - An interactive deep learning book with code, math, and discussions, based on [MXNet](https://mxnet.apache.org/), useful as general learning material. https://d2l.ai/


### PR DESCRIPTION
Added "The Math Behind Artificial Intelligence" - a free freeCodeCamp book to the DL Books section:

- [The Math Behind Artificial Intelligence: A Guide to AI Foundations [Full Book]](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book/) - Free book teaching the math behind AI with plain English explanations and Python code examples

The book:
- Teaches foundational math (Linear Algebra, Calculus, Probability & Statistics and optimization theory) with Python code examples
- Plain English explanations with practical implementations
- Bridges theory and practice for AI/ML learners
- Free and accessible